### PR TITLE
Remove Air Miles card and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This is of course subjective and no card is one-size-fits-all.
 | [Amex Platinum](#amex-personal-platinum)                        | $799         | up to 110,000 MR | $10,000             | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [Amex Cobalt](#amex-cobalt)                                     | $16 / month  | 22,000 pts       | $750 / month        | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [AMEX Gold pers](#amex-personal-gold)                           | $250         | up to 60,000 pts | $12,000             | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
-| [AMEX Marriott pers](#amex-marriott-personal)                   | $120         | 55,000 pts       | $3,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
-| [AMEX Marriott Biz](#amex-marriott-business)                    | $150         | 60,000 pts       | $5,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
+| [AMEX Marriott pers](#amex-marriott-personal)                   | $120         | 110,000 pts      | $6,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
+| [AMEX Marriott Biz](#amex-marriott-business)                    | $150         | 110,000 pts      | $6,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [AMEX Aeroplan core](#amex-aeroplan-core)                       | $120         | up to 40,000 pts | $4,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [Amex Aeroplan Reserve](#amex-aeroplan-reserve)                 | $599         | 90,000 pts       | $7,500              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [BMO Ascend WE MC](#bmo-ascend-world-elite-mc)                  | FYF          | 55,000+ pts      | $4,500              | CCG: Oct. 31, 2025                      | CCG: $125                   |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Best current credit card offers in Canada
 
-**Last Updated:** Nov 30, 2025
+**Last Updated:** Feb 9, 2026
 
 To jump to specific sections of this page, click on the list icon in the top right that's next to the pencil icon.  You can also jump to a specific card's details by clicking on its name in the table.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This is of course subjective and no card is one-size-fits-all.
 | [Amex Cobalt](#amex-cobalt)                                     | $16 / month  | 22,000 pts       | $750 / month        | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [AMEX Gold pers](#amex-personal-gold)                           | $250         | up to 60,000 pts | $12,000             | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [AMEX Marriott pers](#amex-marriott-personal)                   | $120         | 110,000 pts      | $6,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
-| [AMEX Marriott Biz](#amex-marriott-business)                    | $150         | 110,000 pts      | $6,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
+| [AMEX Marriott Biz](#amex-marriott-business)                    | $150         | 110,000 pts      | $10,000             | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [AMEX Aeroplan core](#amex-aeroplan-core)                       | $120         | up to 40,000 pts | $4,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [Amex Aeroplan Reserve](#amex-aeroplan-reserve)                 | $599         | 90,000 pts       | $7,500              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [BMO Ascend WE MC](#bmo-ascend-world-elite-mc)                  | FYF          | 55,000+ pts      | $4,500              | CCG: Oct. 31, 2025                      | CCG: $125                   |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Best current credit card offers in Canada
 
-**Last Updated:** Feb 9, 2026
+**Last Updated:** Mar 29, 2026
 
 To jump to specific sections of this page, click on the list icon in the top right that's next to the pencil icon.  You can also jump to a specific card's details by clicking on its name in the table.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ This is of course subjective and no card is one-size-fits-all.
 ## Lingo
 
 - AF = Annual Fees
-- AM = Air Miles
 - CCG = [creditcardGenius](http://creditcardgenius.ca)
 - FF = [Frugal Flyer](https://frugalflyer.ca/)
 - FYF = First Year Free
@@ -43,7 +42,6 @@ This is of course subjective and no card is one-size-fits-all.
 | [AMEX Aeroplan core](#amex-aeroplan-core)                       | $120         | up to 40,000 pts | $4,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [Amex Aeroplan Reserve](#amex-aeroplan-reserve)                 | $599         | 90,000 pts       | $7,500              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [BMO Ascend WE MC](#bmo-ascend-world-elite-mc)                  | FYF          | 55,000+ pts      | $4,500              | CCG: Oct. 31, 2025                      | CCG: $125                   |
-| [BMO WE Air Miles](#bmo-world-elite-air-miles-mc)               | FYF          | 3,000 AM         | $3,000              | FF: Jun 1, 2026 <br/> CCG: Jun 1, 2026 <br/> GCR: Jun 1, 2026 | FF: $160 <br/> CCG: $150 <br/> FW: $125|
 | [CIBC Aventura Visa Infinite](#cibc-aventura-visa-infinite)     | FYF          | 45,000 pts       | $3,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [CIBC Aventura Visa Gold](#cibc-aventura-visa-gold)             | FYF          | 45,000 pts       | $3,000              | FF: -<br/>CCG: -<br/>GCR: -             | FF: -<br/>CCG: -<br/>GCR: - |
 | [CIBC Dividend Visa Infinite](#cibc-dividend-visa-infinite)     | FYF          | 10% up to $3,000 | -                   | CCG: Oct. 31, 2025                      | CCG: $150                   |
@@ -182,17 +180,6 @@ This is of course subjective and no card is one-size-fits-all.
 - **Sign-up Options:** $125 cashback via GCR
 
 ## BMO Cards
-
-#### BMO World Elite Air Miles MC
-
-- **Annual Fee:** First Year Free (FYF)
-- **Key Benefits:**
-  - 3,000 Air Miles upon spending $4,500 within 110 days
-  - 2,000 Air Miles upon spending $10,000 within 180 days
-  - 2,000 Air Miles upon spending $20,000 within 365 days
-  - Plus, earn an additional bonus 2,000 Air Miles when you spend $1,000 at eligible wholesale clubs, grocery stores, or alcohol retailers within 110 days
-
-- **Sign-up Options:** $160 cashback via FF/ $150 via CCG / $125 via FW
 
 #### BMO Ascend World Elite MC
 


### PR DESCRIPTION
## Description

Remove Air Miles Card since it was replaced by Blue Rewards.

## Source(s) / Verification

https://www.bmo.com/en-ca/main/personal/air-miles-transition-to-blue-rewards/

**Source URL(s) or reference(s):**

## Checklist

- [x] Information has been verified for accuracy
- [x] Formatting is consistent with existing content
